### PR TITLE
Implement Zoocha Simple Form module

### DIFF
--- a/web/modules/custom/zoocha_simple_form/src/Form/ZoochaSimpleForm.php
+++ b/web/modules/custom/zoocha_simple_form/src/Form/ZoochaSimpleForm.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Drupal\zoocha_simple_form\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Database\Connection;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Component\Utility\Html;
+
+/**
+ * Class ZoochaSimpleForm.
+ *
+ * Provides a simple form with a text field and a select list.
+ */
+class ZoochaSimpleForm extends FormBase {
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * The logger service.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a ZoochaSimpleForm object.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger service.
+   */
+  public function __construct(Connection $database, LoggerInterface $logger) {
+    $this->database = $database;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Creates an instance of the form using dependency injection.
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('database'),
+      $container->get('logger.factory')->get('zoocha_simple_form')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Returns a unique string identifying the form.
+   */
+  public function getFormId() {
+    return 'zoocha_simple_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Builds the form elements.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return array
+   *   The form structure.
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // Add a text field to the form.
+    $form['text_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Text Field'), // Title of the text field.
+      '#required' => TRUE, // Marks the field as required.
+      '#maxlength' => 255, // Limit the maximum length for security.
+    ];
+
+    // Add a select list to the form.
+    $form['select_field'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Select Field'), // Title of the select field.
+      '#options' => [
+        'option_1' => $this->t('Option 1'),
+        'option_2' => $this->t('Option 2'),
+      ],
+      '#required' => TRUE, // Marks the field as required.
+    ];
+
+    // Add a submit button to the form.
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Submit'), // Text on the submit button.
+    ];
+
+    return $form; // Returns the form array.
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Handles form submission and stores the submitted data in the database.
+   *
+   * @param array &$form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Retrieve and sanitize values from the form submission.
+    $text = Html::escape($form_state->getValue('text_field'));
+    $select = Html::escape($form_state->getValue('select_field'));
+
+    // Attempt to insert the submitted data into the custom database table.
+    try {
+      // Use Drupal's Database API to perform a safe database insert.
+      $this->database->insert('zoocha_simple_form_data')
+        ->fields([
+          'text_field' => $text,
+          'select_field' => $select,
+        ])
+        ->execute();
+
+      // Display a success message to the user.
+      $this->messenger()->addMessage($this->t('Form submitted successfully.'));
+    }
+    catch (\Exception $e) {
+      // Log the exception with a descriptive message.
+      $this->logger->error('Database error: @message', ['@message' => $e->getMessage()]);
+      // Display a generic error message to the user.
+      $this->messenger()->addError($this->t('An error occurred while submitting the form. Please try again later.'));
+    }
+  }
+
+}

--- a/web/modules/custom/zoocha_simple_form/zoocha_simple_form.info.yml
+++ b/web/modules/custom/zoocha_simple_form/zoocha_simple_form.info.yml
@@ -1,0 +1,7 @@
+name: 'Zoocha Simple Form'
+type: module
+description: 'Provides a simple form with text and select fields.'
+core_version_requirement: ^10
+package: Custom
+dependencies:
+  - drupal:system

--- a/web/modules/custom/zoocha_simple_form/zoocha_simple_form.install
+++ b/web/modules/custom/zoocha_simple_form/zoocha_simple_form.install
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Install file for Zoocha Simple Form module.
+ */
+
+/**
+ * Implements hook_schema().
+ *
+ * Defines the database schema for storing form submissions.
+ */
+function zoocha_simple_form_schema() {
+  $schema['zoocha_simple_form_data'] = [
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+      ],
+      'text_field' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'select_field' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => ['id'],
+  ];
+  return $schema;
+}

--- a/web/modules/custom/zoocha_simple_form/zoocha_simple_form.permissions.yml
+++ b/web/modules/custom/zoocha_simple_form/zoocha_simple_form.permissions.yml
@@ -1,0 +1,4 @@
+# Permission for accessing the Zoocha Simple Form.
+access zoocha simple form:
+  title: 'Access Zoocha Simple Form'
+  description: 'Permission to access the Zoocha simple form.'

--- a/web/modules/custom/zoocha_simple_form/zoocha_simple_form.routing.yml
+++ b/web/modules/custom/zoocha_simple_form/zoocha_simple_form.routing.yml
@@ -1,0 +1,8 @@
+# Route definition for accessing the Zoocha Simple Form.
+zoocha_simple_form.form:
+  path: '/zoocha-simple-form' # URL path to access the form.
+  defaults:
+    _form: '\Drupal\zoocha_simple_form\Form\ZoochaSimpleForm' # The form class.
+    _title: 'Zoocha Simple Form' # Title of the page displaying the form.
+  requirements:
+    _permission: 'access zoocha simple form' # Permission required to access the form.


### PR DESCRIPTION
## Implement Zoocha Simple Form Module

### Summary
This pull request introduces the Zoocha Simple Form module, which provides a basic form with a text field and a select list.

### Features
- A form with a text field and a select list that saves submissions to a custom database table.
- Implementation using dependency injection for the database connection and logger services.
- Secure handling of user inputs with Html::escape() to prevent XSS vulnerabilities.
- Robust error handling with logging and user-friendly messages.
- Proper access control using a custom permission to protect the form.

### Testing
- The module has been tested for successful data submission and error scenarios.
- Verified permissions to ensure only authorized users can access the form.

### Notes
Please review the code and test the module on your local environment to ensure all functionalities work as expected.
