### PR TITLE
Fix Video Publication State Synchronization for Landing Page Content

### DIFF
--- a/web/modules/custom/zoocha_video_sync/src/Services/VideoPublishingService.php
+++ b/web/modules/custom/zoocha_video_sync/src/Services/VideoPublishingService.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\zoocha_video_sync\Services;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\media\Entity\Media;
+use Drupal\node\NodeInterface;
+
+/**
+ * Service class responsible for synchronizing the publication state of videos
+ * with their parent node.
+ */
+class VideoPublishingService {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The logger channel for the module.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a VideoPublishingService object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   The logger channel for the module.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, LoggerChannelInterface $logger) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->logger = $logger;
+  }
+
+  /**
+   * Synchronizes the video state with its parent node.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity being processed.
+   */
+  public function synchronizeVideoState(NodeInterface $node) {
+    // Ensure the node is of type 'landing_page'.
+    if ($node->bundle() === 'landing_page') {
+      $components = $node->get('field_components')->referencedEntities();
+      foreach ($components as $component) {
+        // Check if the component has a field for remote videos.
+        if ($component->hasField('field_remote_video')) {
+          $videos = $component->get('field_remote_video')->referencedEntities();
+          foreach ($videos as $video) {
+            // Ensure the entity is a media and is of the correct bundle.
+            if ($video instanceof Media && $video->bundle() === 'remote_video') {
+              // If the node is unpublished, unpublish all videos.
+              if (!$node->isPublished()) {
+                $this->updateVideoPublishingStatus($video, FALSE);
+              }
+              else {
+                // Otherwise, retain the video's current published status.
+                $this->retainVideoPublishingStatus($video);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Updates the publishing status of a video.
+   *
+   * @param \Drupal\media\Entity\Media $video
+   *   The video entity.
+   * @param bool $publish
+   *   Whether to publish or unpublish the video.
+   */
+  private function updateVideoPublishingStatus(Media $video, $publish) {
+    // Update the status field based on the publication state.
+    $video->set('status', $publish ? 1 : 0);
+    // Save the media entity with error handling.
+    try {
+      $video->save();
+    }
+    catch (\Exception $e) {
+      $this->logger->error('Failed to update video status for media ID ' . $video->id() . ': ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Retains the current publishing status of the video.
+   *
+   * @param \Drupal\media\Entity\Media $video
+   *   The video entity.
+   */
+  private function retainVideoPublishingStatus(Media $video) {
+    // This method is a placeholder if additional logic is needed in the future.
+    // Currently, it is left empty as no action is required to retain the status.
+  }
+}

--- a/web/modules/custom/zoocha_video_sync/zoocha_video_sync.info.yml
+++ b/web/modules/custom/zoocha_video_sync/zoocha_video_sync.info.yml
@@ -1,0 +1,9 @@
+name: Zoocha Video Sync
+type: module
+description: Synchronizes the publication state of videos with their parent node, allowing individual video state control when the parent is published.
+core_version_requirement: ^10
+package: Custom
+dependencies:
+  - drupal:node
+  - drupal:media
+version: '1.0'

--- a/web/modules/custom/zoocha_video_sync/zoocha_video_sync.module
+++ b/web/modules/custom/zoocha_video_sync/zoocha_video_sync.module
@@ -1,0 +1,27 @@
+<?php
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_entity_presave().
+ *
+ * Ensures that video publishing status is synchronized with the parent node.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity being saved.
+ */
+function zoocha_video_sync_entity_presave(EntityInterface $entity) {
+  // Ensure we are dealing with a node entity and specifically a landing page.
+  if ($entity instanceof NodeInterface && $entity->bundle() === 'landing_page') {
+    /** @var \Drupal\zoocha_video_sync\Services\VideoPublishingService $service */
+    $service = \Drupal::service('zoocha_video_sync.video_publishing_service');
+    // Synchronize video state with error handling.
+    try {
+      $service->synchronizeVideoState($entity);
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('zoocha_video_sync')->error('Error synchronizing video state for node ID ' . $entity->id() . ': ' . $e->getMessage());
+    }
+  }
+}

--- a/web/modules/custom/zoocha_video_sync/zoocha_video_sync.services.yml
+++ b/web/modules/custom/zoocha_video_sync/zoocha_video_sync.services.yml
@@ -1,0 +1,9 @@
+services:
+  zoocha_video_sync.video_publishing_service:
+    class: Drupal\zoocha_video_sync\Services\VideoPublishingService
+    arguments: ['@entity_type.manager', '@logger.channel.zoocha_video_sync']
+
+  logger.channel.zoocha_video_sync:
+    class: Drupal\Core\Logger\LoggerChannelFactory
+    factory: ['@logger.factory', 'get']
+    arguments: ['zoocha_video_sync']


### PR DESCRIPTION
### Summary

This Pull Request fixes the synchronization of the publication state of remote videos with their parent `landing_page` node. The changes ensure that when a node is unpublished, all associated videos are also unpublished, and when the node is published, the individual video states are respected as configured.

### Changes

- **Module Configuration:**
  - Added `zoocha_video_sync.info.yml` to define module metadata and dependencies.
  - Configured `zoocha_video_sync.services.yml` to define and manage the video publishing service.

- **Service Implementation:**
  - `VideoPublishingService.php`: Implements logic to synchronize video publication status with the parent node's state.
  - Includes error handling and logging for debugging and monitoring.

- **Hook Implementation:**
  - `zoocha_video_sync.module`: Uses `hook_entity_presave` to trigger video synchronization logic whenever a `landing_page` node is saved.

### Testing

- Confirm that when a `landing_page` node is unpublished, all associated videos are automatically unpublished.
- Verify that when a node is published, the video states are individually respected according to their configured settings.

### Notes

- This fix addresses previous issues with video state management and ensures compliance with Drupal best practices for modularity and dependency management.
- Logs have been included for key actions to aid in troubleshooting and verification of functionality.
