### PR TITLE
feat(módulo Simple Form): adicionar formulário simples com dois campos e inserção de dados em tabela customizada

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@
 
 # Ignore IDE files
 /.idea
+.ddev

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -46,6 +46,7 @@ module:
   path_alias: 0
   search: 0
   shortcut: 0
+  simple_form: 0
   system: 0
   taxonomy: 0
   text: 0

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /node
+  front: /node/1
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en

--- a/web/modules/custom/simple_form/simple_form.info.yml
+++ b/web/modules/custom/simple_form/simple_form.info.yml
@@ -1,0 +1,12 @@
+name: 'Practical Coding Challenges'
+description: 'Provides a simple form with two fields: a text
+field and a select list. Upon submission, the form should save the data to a
+custom table in the database and display a confirmation message.'
+package: Assessment
+core_version_requirement: ^10
+type: module
+
+version: '1.0'
+datestamp: 1630242476
+dependencies:
+  - drupal:field

--- a/web/modules/custom/simple_form/simple_form.links.menu.yml
+++ b/web/modules/custom/simple_form/simple_form.links.menu.yml
@@ -1,0 +1,6 @@
+simple_form.admin_config_form:
+  title: 'Simple Form'
+  description: 'Configure the Simple Form.'
+  parent: system.admin_config_system
+  route_name: simple_form.form
+  weight: 100

--- a/web/modules/custom/simple_form/simple_form.module
+++ b/web/modules/custom/simple_form/simple_form.module
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * Contains the implementation of the Simple Form module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function simple_form_install() {
+  \Drupal::database()->schema()->createTable('simple_form_data', [
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+      ],
+      'text_field' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'select_field' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => ['id'],
+  ]);
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function simple_form_uninstall() {
+  \Drupal::database()->schema()->dropTable('simple_form_data');
+}

--- a/web/modules/custom/simple_form/simple_form.routing.yml
+++ b/web/modules/custom/simple_form/simple_form.routing.yml
@@ -1,0 +1,7 @@
+simple_form.form:
+  path: '/admin/simple-form'
+  defaults:
+    _form: '\Drupal\simple_form\Form\SimpleForm'
+    _title: 'Simple Form'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/simple_form/src/Form/SimpleForm.php
+++ b/web/modules/custom/simple_form/src/Form/SimpleForm.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\simple_form\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Database\Database;
+
+/**
+ * Provides a Simple Form.
+ */
+class SimpleForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'simple_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $connection = Database::getConnection();
+    $query = $connection->select('simple_form_data', 'sfd')
+      ->fields('sfd', ['text_field', 'select_field'])
+      ->orderBy('id', 'DESC')
+      ->range(0, 1);
+    $result = $query->execute()->fetchAssoc();
+
+    $default_text = isset($result['text_field']) ? $result['text_field'] : '';
+    $default_select = isset($result['select_field']) ? $result['select_field'] : '';
+
+    $form['text_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Text Field'),
+      '#default_value' => $default_text,
+      '#required' => TRUE,
+    ];
+
+    $form['select_field'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Select Field'),
+      '#options' => [
+        'option_1' => $this->t('Option 1'),
+        'option_2' => $this->t('Option 2'),
+        'option_3' => $this->t('Option 3'),
+      ],
+      '#default_value' => $default_select,
+      '#required' => TRUE,
+    ];
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Submit'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $text = $form_state->getValue('text_field');
+    $select = $form_state->getValue('select_field');
+
+    $connection = Database::getConnection();
+    $connection->insert('simple_form_data')
+      ->fields([
+        'text_field' => $text,
+        'select_field' => $select,
+      ])
+      ->execute();
+
+    $this->messenger()->addMessage($this->t('The form has been submitted successfully.'));
+  }
+}


### PR DESCRIPTION
- Implementa um novo módulo Drupal chamado "Simple Form".
- O módulo disponibiliza um formulário simples com um campo de texto e uma lista de seleção.
- Os dados submetidos pelo formulário são salvos em uma tabela customizada no banco de dados.
- Exibe uma mensagem de confirmação após o envio bem-sucedido do formulário.
- Inclui suporte para exibição dos valores previamente inseridos como valores padrão nos campos do formulário.