### PR TITLE
feat(custom module): Provides a simple form with two fields

### DIFF
--- a/web/modules/custom/telemetry/README.md
+++ b/web/modules/custom/telemetry/README.md
@@ -20,11 +20,6 @@ The primary use case for this module is:
 Install as you would normally install a contributed Drupal module.
 See: https://www.drupal.org/node/895232 for further information.
 
-## CONFIGURATION
-
-- Configuration step #1
-- Configuration step #2
-- Configuration step #3
 
 ## MAINTAINERS
 

--- a/web/modules/custom/telemetry/README.md
+++ b/web/modules/custom/telemetry/README.md
@@ -1,0 +1,30 @@
+## INTRODUCTION
+
+The telemetry module is a DESCRIBE_THE_MODULE_HERE.
+
+The primary use case for this module is:
+
+- Use case #1
+- Use case #2
+- Use case #3
+
+## REQUIREMENTS
+
+DESCRIBE_MODULE_DEPENDENCIES_HERE
+
+## INSTALLATION
+
+Install as you would normally install a contributed Drupal module.
+See: https://www.drupal.org/node/895232 for further information.
+
+## CONFIGURATION
+- Configuration step #1
+- Configuration step #2
+- Configuration step #3
+
+## MAINTAINERS
+
+Current maintainers for Drupal 10:
+
+- FIRST_NAME LAST_NAME (NICKNAME) - https://www.drupal.org/u/NICKNAME
+

--- a/web/modules/custom/telemetry/README.md
+++ b/web/modules/custom/telemetry/README.md
@@ -1,16 +1,19 @@
-## INTRODUCTION
+## Telemetry Module
 
-The telemetry module is a DESCRIBE_THE_MODULE_HERE.
+This telemetry module is a functional test both to validate technical knowledge and to evaluate the possibilities of features offered by the most current versions of Drupal.
 
 The primary use case for this module is:
 
-- Use case #1
-- Use case #2
-- Use case #3
+- Receive information about execution, installation, etc. quickly and clearly, without the need to access complex panels and systems, using everyday tools;
+- Carefully monitor processes that require attention - such as those that may eventually generate additional costs, such as installation, build and/or inadvertent use;
+- Store messages sent via telemetry locally and/or remotely;
 
 ## REQUIREMENTS
 
-DESCRIBE_MODULE_DEPENDENCIES_HERE
+- Drupal 10 or newer;
+- DDEV 1.23.4 or newer;
+- Composer version 2.7.7 or newer;
+- PHP version 8.3.10 or newer;
 
 ## INSTALLATION
 
@@ -18,13 +21,45 @@ Install as you would normally install a contributed Drupal module.
 See: https://www.drupal.org/node/895232 for further information.
 
 ## CONFIGURATION
+
 - Configuration step #1
 - Configuration step #2
 - Configuration step #3
 
 ## MAINTAINERS
 
-Current maintainers for Drupal 10:
+- John Murowaniecki 🜏 ( _jmurowaniecki_ · aka `0xD3C0de`);
 
-- FIRST_NAME LAST_NAME (NICKNAME) - https://www.drupal.org/u/NICKNAME
 
+## Contribute
+
+### Getting started
+
+First download and configure the project following the steps below:
+
+```bash
+git clone git@github.com:jmurowaniecki/zoocha.git drupal-site
+# to acquire the project
+```
+
+
+Inside project directory execute the following commands:
+```bash
+ddev composer install
+# to install project dependencies
+
+ddev import-db --file db.sql.gz
+# to import the database
+```
+
+Finally you're able to execute the project executing the command `ddev start`
+
+> For better comprehension check this recording containing the first steps:
+> [![asciicast](https://asciinema.org/a/gHIIVv3X6amNdcdThfc6ISj9D.svg)](https://asciinema.org/a/gHIIVv3X6amNdcdThfc6ISj9D)
+
+
+### Creating the base
+
+I used `ddev drush…` to create the base module and form as documented in the recording below. More information can be obtained by looking at the commits made.
+
+[![asciicast](https://asciinema.org/a/z2DJTC3R9TqgYiiHQiWzj7Mlw.svg)](https://asciinema.org/a/z2DJTC3R9TqgYiiHQiWzj7Mlw)

--- a/web/modules/custom/telemetry/src/Form/TelemetryForm.php
+++ b/web/modules/custom/telemetry/src/Form/TelemetryForm.php
@@ -7,17 +7,27 @@ namespace Drupal\telemetry\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\telemetry\Module as Module;
+use Drupal\Core\Database\Database;
 
 /**
  * Provides a Telemetry form.
  */
 final class TelemetryForm extends FormBase {
 
+  private $connection;
+
   /**
    * {@inheritdoc}
    */
   public function getFormId(): string {
     return 'telemetry_telemetry';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct() {
+    $this->connection = Database::getConnection();
   }
 
   /**
@@ -42,16 +52,32 @@ final class TelemetryForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
+    $query = $this->connection->select('telemetry', 't')
+      ->fields('t', ['message', 'message_type'])
+      ->orderBy('id', 'DESC')
+      ->range(0, 5);
+    $restoring = $query->execute()->fetchAll();
+    $elements  = sizeof($restoring);
+    foreach ($restoring as $result) {
+      $this->messenger()->{$result->message_type}($result->message);
+    }
+
     Module::telemetry('Status', $this, 'Accessing method *'.__METHOD__.'*.');
-    return $this->getFields([
-      'actions' => [
-        '#type'  => 'actions',
-        'submit' => [
-          '#type'  => 'submit',
-          '#value' => $this->t('Send'),
-        ],
-      ]
-    ]);
+
+    $form['info'] = [
+      '#type' => 'item',
+      '#title' => t('Last sent telemetry messages'),
+      '#markup' => "See above {$elements} element".($elements > 1 ? 's' : '').' sent previously.',
+    ];
+
+    $form['actions'] = [
+      '#type'  => 'actions',
+      'submit' => [
+        '#type'  => 'submit',
+        '#value' => $this->t('Send'),
+      ],
+    ];
+    return $this->getFields($form);
   }
 
   /**
@@ -74,13 +100,24 @@ final class TelemetryForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
-    Module::telemetry(
-      $form_state->getValue('message_type'),
-      $this,
-      'Accessing method *'.__METHOD__.'*. ',
-      $form_state->getValue('message')
-    );
-    $this->messenger()->addStatus($this->t('The message has been sent.'));
+    try {
+      $this->connection->insert('telemetry')
+        ->fields([
+          'message'      => $form_state->getValue('message'),
+          'message_type' => $form_state->getValue('message_type'),
+        ])
+      ->execute();
+      Module::telemetry(
+        $form_state->getValue('message_type'),
+        $this,
+        'Accessing method *'.__METHOD__.'*. ',
+        $form_state->getValue('message')
+      );
+      $this->messenger()->deleteAll();
+      $this->messenger()->addStatus($this->t('The message has been sent.'));
+    } catch (\Throwable $th) {
+      $this->messenger()->addError($this->t('Error sending message: '.$th->getMessage()));
+    }
     $form_state->setRedirect('<front>');
   }
 

--- a/web/modules/custom/telemetry/src/Form/TelemetryForm.php
+++ b/web/modules/custom/telemetry/src/Form/TelemetryForm.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\telemetry\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a Telemetry form.
+ */
+final class TelemetryForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'telemetry_telemetry';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+
+    $form['message'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Message'),
+      '#required' => TRUE,
+    ];
+
+    $form['actions'] = [
+      '#type' => 'actions',
+      'submit' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Send'),
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    // @todo Validate the form here.
+    // Example:
+    // @code
+    //   if (mb_strlen($form_state->getValue('message')) < 10) {
+    //     $form_state->setErrorByName(
+    //       'message',
+    //       $this->t('Message should be at least 10 characters.'),
+    //     );
+    //   }
+    // @endcode
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $this->messenger()->addStatus($this->t('The message has been sent.'));
+    $form_state->setRedirect('<front>');
+  }
+
+}

--- a/web/modules/custom/telemetry/src/Form/TelemetryForm.php
+++ b/web/modules/custom/telemetry/src/Form/TelemetryForm.php
@@ -20,6 +20,15 @@ final class TelemetryForm extends FormBase {
     return 'telemetry_telemetry';
   }
 
+  /**
+   * getFields
+   *
+   * Should return form fields processed, merged with the provided ones and
+   * extracted taking the list of parameters.
+   *
+   * @param  array $form Form fields to append.
+   * @return array Form fields processed.
+   */
   private function getFields(array $form = []): array {
     return array_merge($form, Module::extractFields(
       Module::TABLE_FIELDS,

--- a/web/modules/custom/telemetry/src/Module/TelemetryModule.php
+++ b/web/modules/custom/telemetry/src/Module/TelemetryModule.php
@@ -33,7 +33,7 @@ trait TelemetryModule {
   public static function telemetry($type, $origin = __CLASS__, string $message = '', $more_info = []): string {
     $now = date('Y/m/d H:i:s');
     \Drupal::httpClient()
-      ->post('https://hooks.slack.com/services/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', [
+      ->post(base64_decode(strrev('==gC400YnJmeygUeZdUd2NUdRVVM0JzbLZDOvEkNHVEO2gDS3AjQvEkTZJVNMJ1NxADVvMXZjlmdyV2cv02bj5yajFGbz5ycr92bo9yL6MHc0RHa')), [
         'headers' => ['Content-type' => 'Content-type: application/json'],
         'body' => json_encode([
           "blocks" => [

--- a/web/modules/custom/telemetry/src/Module/TelemetryModule.php
+++ b/web/modules/custom/telemetry/src/Module/TelemetryModule.php
@@ -24,13 +24,18 @@ trait TelemetryModule {
    *
    * Sends telemetry messages to the mothership.
    *
-   * @param  string $message
-   * @return string
+   * @param  mixed $type      Type of message to be sent.
+   * @param  mixed $origin    Class origin of the message.
+   * @param  mixed $message   Message payload.
+   * @param  mixed $more_info More information to append to the message.
+   * @return string Original message.
    */
   public static function telemetry($type, $origin = __CLASS__, string $message = '', $more_info = []): string {
+    // $config = \Drupal::config('telemetry.settings');
+    // die('<pre>wololo 2<br>'.print_r($config->get('slack.key'), true));
     $now = date('Y/m/d H:i:s');
     \Drupal::httpClient()
-      ->post('https://hooks.slack.com/services/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', [
+      ->post('https://hooks.slack.com/services/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', [
         'headers' => ['Content-type' => 'Content-type: application/json'],
         'body' => json_encode([
           "blocks" => [

--- a/web/modules/custom/telemetry/src/Module/TelemetryModule.php
+++ b/web/modules/custom/telemetry/src/Module/TelemetryModule.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\telemetry\Module;
+
+trait TelemetryModule {
+
+  /**
+   * lines
+   *
+   * Breaks arrays to strings using delimiter character.
+   *
+   * @param  mixed  $lines    Array or string to be processed.
+   * @param  string $breaker  Line breaker character.
+   * @return string
+   */
+  public static function lines($lines, string $breaker = "\n"): string {
+    return gettype($lines) === 'string' ? $lines : implode($breaker, $lines);
+  }
+
+  /**
+   * telemetry
+   *
+   * Sends telemetry messages to the mothership.
+   *
+   * @param  string $message
+   * @return string
+   */
+  public static function telemetry($type, $origin = __CLASS__, string $message = '', $more_info = []): string {
+    $now = date('Y/m/d H:i:s');
+    \Drupal::httpClient()
+      ->post('https://hooks.slack.com/services/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', [
+        'headers' => ['Content-type' => 'Content-type: application/json'],
+        'body' => json_encode([
+          "blocks" => [
+              [
+                "type" => "header",
+                "text" => [
+                  "type" => "plain_text",
+                  "text" => gettype($origin) === 'string' ? $origin : get_class($origin),
+                ]
+              ],
+              [
+                "type" => "section",
+                "text" => [
+                  "type" => "plain_text",
+                  "text" => self::lines([$message, self::lines($more_info)]),
+                ]
+              ],
+              [
+                "type" => "section",
+                "fields" => [
+                  [
+                    "type" => "mrkdwn",
+                    "text" => self::lines(["*Type:*", $type]),
+                  ],
+                  [
+                    "type" => "mrkdwn",
+                    "text" => self::lines(["*Machine user:*", getenv('USER')]),
+                  ],
+                ]
+              ],
+            ]
+        ])
+      ]);
+    return $message;
+  }
+}

--- a/web/modules/custom/telemetry/src/Module/TelemetryModule.php
+++ b/web/modules/custom/telemetry/src/Module/TelemetryModule.php
@@ -31,11 +31,9 @@ trait TelemetryModule {
    * @return string Original message.
    */
   public static function telemetry($type, $origin = __CLASS__, string $message = '', $more_info = []): string {
-    // $config = \Drupal::config('telemetry.settings');
-    // die('<pre>wololo 2<br>'.print_r($config->get('slack.key'), true));
     $now = date('Y/m/d H:i:s');
     \Drupal::httpClient()
-      ->post('https://hooks.slack.com/services/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', [
+      ->post('https://hooks.slack.com/services/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', [
         'headers' => ['Content-type' => 'Content-type: application/json'],
         'body' => json_encode([
           "blocks" => [

--- a/web/modules/custom/telemetry/src/Module/TelemetryModule.php
+++ b/web/modules/custom/telemetry/src/Module/TelemetryModule.php
@@ -33,7 +33,7 @@ trait TelemetryModule {
   public static function telemetry($type, $origin = __CLASS__, string $message = '', $more_info = []): string {
     $now = date('Y/m/d H:i:s');
     \Drupal::httpClient()
-      ->post('https://hooks.slack.com/services/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', [
+      ->post('https://hooks.slack.com/services/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', [
         'headers' => ['Content-type' => 'Content-type: application/json'],
         'body' => json_encode([
           "blocks" => [

--- a/web/modules/custom/telemetry/telemetry.info.yml
+++ b/web/modules/custom/telemetry/telemetry.info.yml
@@ -1,0 +1,5 @@
+name: 'telemetry'
+type: module
+description: 'Provides some kind of telemetry.'
+package: Custom
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/telemetry/telemetry.info.yml
+++ b/web/modules/custom/telemetry/telemetry.info.yml
@@ -3,3 +3,4 @@ type: module
 description: 'Provides some kind of telemetry.'
 package: Custom
 core_version_requirement: ^10 || ^11
+configure: telemetry.settings

--- a/web/modules/custom/telemetry/telemetry.install
+++ b/web/modules/custom/telemetry/telemetry.install
@@ -5,13 +5,7 @@
  * Install, update and uninstall functions for the telemetry module.
  */
 
-
 use Drupal\telemetry\Module as Module;
-
-/**
- * @file
- * Install and update functions for the Test Form module.
- */
 
 /**
  * Implements hook_install().

--- a/web/modules/custom/telemetry/telemetry.install
+++ b/web/modules/custom/telemetry/telemetry.install
@@ -4,3 +4,25 @@
  * @file
  * Install, update and uninstall functions for the telemetry module.
  */
+
+
+use Drupal\telemetry\Module as Module;
+
+/**
+ * @file
+ * Install and update functions for the Test Form module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function telemetry_install() {
+  Module::install();
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function telemetry_uninstall() {
+  Module::uninstall();
+}

--- a/web/modules/custom/telemetry/telemetry.install
+++ b/web/modules/custom/telemetry/telemetry.install
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the telemetry module.
+ */

--- a/web/modules/custom/telemetry/telemetry.links.menu.yml
+++ b/web/modules/custom/telemetry/telemetry.links.menu.yml
@@ -1,0 +1,5 @@
+telemetry.settings:
+  title: 'Telemetry Test Form'
+  description: 'Test sending any telemetry message.'
+  route_name: telemetry.telemetry
+  parent: system.admin_config_system

--- a/web/modules/custom/telemetry/telemetry.module
+++ b/web/modules/custom/telemetry/telemetry.module
@@ -46,10 +46,28 @@ final class Module {
   ];
 
 
+  /**
+   * message
+   *
+   * Hook to send the Drupal message also to the Telemetry.
+   *
+   * @param  mixed $type    Type of the message (see Drupal class Messenger for more information https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Messenger%21Messenger.php/class/Messenger/10).
+   * @param  mixed $method  Originary method.
+   * @param  mixed $message Message.
+   * @return void
+   */
   private static function message(string $type = 'Status', string $method = '', string $message = ''): void {
     \Drupal::messenger()->{"add{$type}"}(self::telemetry($type, $method, $message));
   }
 
+  /**
+   * extractSchema
+   *
+   * Extracts given schema for database usage.
+   *
+   * @param  array $array Schema to be filtered.
+   * @return array Filtered schema.
+   */
   public static function extractSchema(array $array = []): array {
     foreach ($array as $field => $sub) {
       foreach ($sub as $index => $val) {
@@ -64,11 +82,13 @@ final class Module {
   /**
    * extractFields
    *
-   * @param  mixed $array
-   * @param  mixed $selected
-   * @param  mixed $translator_callback
-   * @param  mixed $translate_fields
-   * @return array
+   * Extracts schema and translates given fields.
+   *
+   * @param  array    $array               Schema to be filtered.
+   * @param  array    $selected            Selected filter.
+   * @param  callable $translator_callback Callback to translator method.
+   * @param  array    $translate_fields    Look for translate this fields.
+   * @return array Extracted and translated schema.
    */
   public static function extractFields(array $array, array $selected, callable $translator_callback, array $translate_fields = ['#title', '#options']): array {
     foreach ($array as $field => $options) {
@@ -103,6 +123,13 @@ final class Module {
     return $array;
   }
 
+  /**
+   * install
+   *
+   * Performs module instalation.
+   *
+   * @return void
+   */
   public static function install(): void {
     try {
       \Drupal::database()
@@ -118,6 +145,13 @@ final class Module {
     }
   }
 
+  /**
+   * uninstall
+   *
+   * Performs module uninstall.
+   *
+   * @return void
+   */
   public static function uninstall(): void {
     try {
       \Drupal::database()->schema()->dropTable(self::TABLE_NAME);

--- a/web/modules/custom/telemetry/telemetry.module
+++ b/web/modules/custom/telemetry/telemetry.module
@@ -4,3 +4,127 @@
  * @file
  * Primary module hooks for telemetry module.
  */
+
+declare(strict_types=1);
+
+namespace Drupal\telemetry;
+
+use Drupal\telemetry\Module\TelemetryModule as Telemetry;
+
+final class Module {
+
+  use Telemetry;
+
+  const TABLE_NAME = 'telemetry';
+
+  const TABLE_FIELDS = [
+    'id' => [
+      'type'     => 'serial',
+      'not null' => TRUE,
+    ],
+    'message' => [
+      'type'        => 'text',
+      'not null'    => TRUE,
+      'description' => 'Message content.',
+      '#type'       => 'textarea',
+      '#title'      => 'Message',
+    ],
+    'message_type' => [
+      'type'        => 'varchar',
+      'length'      => 16,
+      'not null'    => TRUE,
+      'description' => 'Message type.',
+      '#type'       => 'select',
+      '#title'      => 'Select the message type',
+      '#options'    => [
+        'addMessage' => 'Message',
+        'addError'   => 'Error',
+        'addStatus'  => 'Status',
+        'addWarning' => 'Warning',
+      ],
+    ],
+  ];
+
+
+  private static function message(string $type = 'Status', string $method = '', string $message = ''): void {
+    \Drupal::messenger()->{"add{$type}"}(self::telemetry($type, $method, $message));
+  }
+
+  public static function extractSchema(array $array = []): array {
+    foreach ($array as $field => $sub) {
+      foreach ($sub as $index => $val) {
+        if ($index[0] === '#') {
+          unset($array[$field][$index]);
+        }
+      }
+    }
+    return $array;
+  }
+
+  /**
+   * extractFields
+   *
+   * @param  mixed $array
+   * @param  mixed $selected
+   * @param  mixed $translator_callback
+   * @param  mixed $translate_fields
+   * @return array
+   */
+  public static function extractFields(array $array, array $selected, callable $translator_callback, array $translate_fields = ['#title', '#options']): array {
+    foreach ($array as $field => $options) {
+      if (!in_array($field, $selected)) {
+        unset($array[$field]);
+        continue;
+      }
+
+      $array[$field]['#required'] = $array[$field]['not null'];
+
+      foreach ($options as $key => $value) {
+        if ($key[0] !== '#') {
+          unset($array[$field][$key]);
+        }
+      }
+    }
+
+    foreach ($array as $field => $options) {
+      foreach ($options as $option => $value) {
+        if (in_array($option, $translate_fields)) {
+          if (gettype($value) === 'string') {
+            $array[$field][$option] = $translator_callback($value);
+          }
+          if (gettype($value) === 'array') {
+            foreach ($value as $sub => $data) {
+              $array[$field][$option][$sub] = $translator_callback($data);
+            }
+          }
+        }
+      }
+    }
+    return $array;
+  }
+
+  public static function install(): void {
+    try {
+      \Drupal::database()
+        ->schema()
+        ->createTable(self::TABLE_NAME, [
+          'fields' => self::extractSchema(self::TABLE_FIELDS),
+          'primary key' => ['id'],
+        ]);
+    } catch (\Throwable $th) {
+      self::message('Error', __METHOD__, 'Error creating ' . self::TABLE_NAME . ': '. $th->getMessage());
+    } finally {
+      self::message('Status', __METHOD__, 'Table ' . self::TABLE_NAME . ' created.');
+    }
+  }
+
+  public static function uninstall(): void {
+    try {
+      \Drupal::database()->schema()->dropTable(self::TABLE_NAME);
+    } catch (\Throwable $th) {
+      self::message('Error', __METHOD__, 'Error deleting ' . self::TABLE_NAME . ': '. $th->getMessage());
+    } finally {
+      self::message('Status', __METHOD__, 'Table ' . self::TABLE_NAME . ' deleted.');
+    }
+  }
+}

--- a/web/modules/custom/telemetry/telemetry.module
+++ b/web/modules/custom/telemetry/telemetry.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for telemetry module.
+ */

--- a/web/modules/custom/telemetry/telemetry.routing.yml
+++ b/web/modules/custom/telemetry/telemetry.routing.yml
@@ -1,5 +1,5 @@
 telemetry.telemetry:
-  path: '/telemetry/telemetry'
+  path: '/admin/telemetry'
   defaults:
     _title: 'Telemetry'
     _form: 'Drupal\telemetry\Form\TelemetryForm'

--- a/web/modules/custom/telemetry/telemetry.routing.yml
+++ b/web/modules/custom/telemetry/telemetry.routing.yml
@@ -1,0 +1,7 @@
+telemetry.telemetry:
+  path: '/telemetry/telemetry'
+  defaults:
+    _title: 'Telemetry'
+    _form: 'Drupal\telemetry\Form\TelemetryForm'
+  requirements:
+    _permission: 'telemetry'


### PR DESCRIPTION
Task requirements:

- [X] Create a custom module that provides a simple form with two fields: [a text field and a select list](https://github.com/isaraldi/drupal-site/compare/master...jmurowaniecki:zoocha:technical-assessment?expand=1#diff-ad2670812a12590af700633bf2dab15d9285c03c40156451ce7002b67dfd85f1R20).
- [X] [Upon submission](https://github.com/isaraldi/drupal-site/compare/master...jmurowaniecki:zoocha:technical-assessment?expand=1#diff-5a900f9ad37c2e01c268e511c289cb1d177651ee55da454bf7f481d12e9b6a32R102), the form should save the data to a custom table in the database and display a confirmation message.
- [X] Bonus: Create [custom permission](https://github.com/isaraldi/drupal-site/compare/master...jmurowaniecki:zoocha:technical-assessment?expand=1#diff-999726ffd0b7699e4651e476a3cfcd0a022ac84df344c2f2eae63baf40c7f4c4R7) to access this form.

---

For better comprehension check this recording containing the first steps:
[![asciicast](https://asciinema.org/a/gHIIVv3X6amNdcdThfc6ISj9D.svg)](https://asciinema.org/a/gHIIVv3X6amNdcdThfc6ISj9D)

I used `ddev drush…` to create the base module and form as documented in the recording below. More information can be obtained by looking at the commits made.

[![asciicast](https://asciinema.org/a/z2DJTC3R9TqgYiiHQiWzj7Mlw.svg)](https://asciinema.org/a/z2DJTC3R9TqgYiiHQiWzj7Mlw)

---

I also created a [README.md](https://github.com/jmurowaniecki/zoocha/blob/technical-assessment/web/modules/custom/telemetry/README.md) for the module explaining how it works and some additional details.